### PR TITLE
fix for UTF8 strings that use more than 1 byte, check UTF8 specs

### DIFF
--- a/tests/unit/message.js
+++ b/tests/unit/message.js
@@ -51,7 +51,7 @@ QUnit.test("Send and receive a message with a multi-byte UTF8 string", function 
   client.connect(TEST.login, TEST.password,
     function () {
       client.subscribe(TEST.destination, function (message) {
-        assert.equal(message.body, payload);
+        assert.equal(message.body.replace(/^"(.+(?="$))"$/, '$1'), payload);
         assert.equal(message.body.length, 28);
         client.disconnect();
 

--- a/tests/unit/message.js
+++ b/tests/unit/message.js
@@ -24,7 +24,7 @@ QUnit.test("Send and receive a message with a JSON body", function (assert) {
   var done = assert.async();
 
   var client = stompClient();
-  var payload = {text: "hello", bool: true, value: Math.random()};
+  var payload = { text: "hello", bool: true, value: Math.random() };
 
   client.connect(TEST.login, TEST.password,
     function () {
@@ -33,6 +33,26 @@ QUnit.test("Send and receive a message with a JSON body", function (assert) {
         assert.equal(res.text, payload.text);
         assert.equal(res.bool, payload.bool);
         assert.equal(res.value, payload.value);
+        client.disconnect();
+
+        done();
+      });
+
+      client.send(TEST.destination, {}, JSON.stringify(payload));
+    });
+});
+
+QUnit.test("Send and receive a message with a multi-byte UTF8 string", function (assert) {
+  var done = assert.async();
+
+  var client = stompClient();
+  var payload = "Älä sinä yhtään and السابق";
+
+  client.connect(TEST.login, TEST.password,
+    function () {
+      client.subscribe(TEST.destination, function (message) {
+        assert.equal(message.body, payload);
+        assert.equal(message.body.lenth, 26);
         client.disconnect();
 
         done();

--- a/tests/unit/message.js
+++ b/tests/unit/message.js
@@ -52,7 +52,7 @@ QUnit.test("Send and receive a message with a multi-byte UTF8 string", function 
     function () {
       client.subscribe(TEST.destination, function (message) {
         assert.equal(message.body, payload);
-        assert.equal(message.body.length, 26);
+        assert.equal(message.body.length, 28);
         client.disconnect();
 
         done();

--- a/tests/unit/message.js
+++ b/tests/unit/message.js
@@ -52,7 +52,7 @@ QUnit.test("Send and receive a message with a multi-byte UTF8 string", function 
     function () {
       client.subscribe(TEST.destination, function (message) {
         assert.equal(message.body, payload);
-        assert.equal(message.body.lenth, 26);
+        assert.equal(message.body.length, 26);
         client.disconnect();
 
         done();

--- a/tests/unit/message.js
+++ b/tests/unit/message.js
@@ -51,13 +51,12 @@ QUnit.test("Send and receive a message with a multi-byte UTF8 string", function 
   client.connect(TEST.login, TEST.password,
     function () {
       client.subscribe(TEST.destination, function (message) {
-        assert.equal(message.body.replace(/^"(.+(?="$))"$/, '$1'), payload);
-        assert.equal(message.body.length, 28);
+        assert.equal(message.body, payload);
         client.disconnect();
 
         done();
       });
 
-      client.send(TEST.destination, {}, JSON.stringify(payload));
+      client.send(TEST.destination, {}, payload);
     });
 });


### PR DESCRIPTION
UTF8 strings can be 1 to 4 8 bit bytes, example fix that covers broader scope of the UTF8 character spec.
resolve #44